### PR TITLE
Fix non-integer array indexing in line drawing algorithm

### DIFF
--- a/ect.py
+++ b/ect.py
@@ -71,7 +71,7 @@ def line(image, point1, point2, color, timer):
     y = y1
     
     for v in range(steps + 1):
-        image2[y,x] = color 
+        image2[int(round(y)), int(round(x))] = color 
         x = x + Xincrement;
         y = y + Yincrement;
       


### PR DESCRIPTION
### Summary
This pull request addresses an issue with non-integer array indexing in the line drawing algorithm within `ect.py`. 

### Changes Made
- Replaced `image2[y, x] = color` with `image2[int(round(y)), int(round(x))] = color`.

### Reason for Change
The original indexing method using `image2[y, x] = color` can lead to runtime errors when non-integer values are provided for `y` and `x`. This is especially problematic when the coordinates are calculated from floating-point operations, which can result in non-integer values.

By changing the indexing to `image2[int(round(y)), int(round(x))] = color`, we ensure that the coordinates are rounded to the nearest integers before being used for indexing. This modification prevents runtime errors and guarantees that the drawing function behaves consistently with the expected integer index requirements. The new method is more robust and handles various input scenarios better.

### Testing
To verify the changes, you can run the drawing function with both integer and non-integer inputs to ensure it behaves as expected without raising errors.
